### PR TITLE
Rails5の環境構築にて、現状のrbenvの挙動を反映

### DIFF
--- a/Ruby on Rails/環境構築/2 Rails5の環境構築（macOS）.md
+++ b/Ruby on Rails/環境構築/2 Rails5の環境構築（macOS）.md
@@ -1,6 +1,6 @@
 > ここではmacOSにおけるRuby on Railsの環境構築方法を記載しています。対応バージョンは以下の通りです。
 >
-> - Ruby 2.6.5
+> - Ruby 2.6.6
 > - Rails 5.2.3
 >
 > Rails6を使う場合は[こちら](https://github.com/Techpit-Market/environment-construction-kit/blob/master/Ruby%20on%20Rails%20%E7%92%B0%E5%A2%83%E6%A7%8B%E7%AF%89%E3%82%AD%E3%83%83%E3%83%88/3%20Rails6%E3%81%AE%E7%92%B0%E5%A2%83%E6%A7%8B%E7%AF%89%EF%BC%88macOS%EF%BC%89.md)を参照ください。
@@ -105,22 +105,22 @@ Only latest stable releases for each Ruby implementation are shown.
 Use 'rbenv install --list-all' to show all local versions.
 ```
 
-現在の最新のバージョンは2.6.5になるので、2.6.5のバージョンをインストールします。（2019年11月時点）
+現在の最新のバージョンは2.6.6になるので、2.6.6のバージョンをインストールします。（2020年12月時点）
 
-2.6.5のバージョンが表示されない場合は、rbenvとruby​​-buildを最新にアップグレードする必要があります。
+2.6.6のバージョンが表示されない場合は、rbenvとruby​​-buildを最新にアップグレードする必要があります。
 
 参考：[rbenv Upgrading with Homebrew](https://github.com/rbenv/rbenv#upgrading-with-homebrew)
 
 それでは、以下のコマンドを実行してください。(インストール完了まで数分かかることがあります。)
 
 ```
-$ rbenv install 2.6.5
+$ rbenv install 2.6.6
 ```
 
 インストールが完了したら、PC（サーバー）内で共通に使うためにグローバルで利用するバージョンを設定します。
 
 ```
-$ rbenv global 2.6.5
+$ rbenv global 2.6.6
 ```
 
 プロジェクトごとにRubyのバージョンを指定する場合は`global`ではなく`local`を使います。
@@ -129,7 +129,7 @@ $ rbenv global 2.6.5
 
 ```
 $ ruby -v
-ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-darwin19]
+ruby 2.6.6p146 (2020-03-31 revision 67876) [x86_64-darwin19]
 ```
 
 

--- a/Ruby on Rails/環境構築/2 Rails5の環境構築（macOS）.md
+++ b/Ruby on Rails/環境構築/2 Rails5の環境構築（macOS）.md
@@ -88,38 +88,21 @@ $ source ~/.bash_profile
 $ rbenv install -l
 ```
 
-すると下記のようにrubyのインストール可能なバージョンの一覧が表示されます。
+コマンドを実行すると、最新の安定版のバージョンが一覧で表示されます。
 
 ```
-Available versions:
-  1.8.5-p52
-  1.8.5-p113
-  1.8.5-p114
-  ---中略---
-  2.5.0
-  2.5.1
-  2.5.2
-  2.5.3
-  2.5.4
-  2.5.5
-  2.5.6
-  2.5.7
-  2.6.0-dev
-  2.6.0-preview1
-  2.6.0-preview2
-  2.6.0-preview3
-  2.6.0-rc1
-  2.6.0-rc2
-  2.6.0
-  2.6.1
-  2.6.2
-  2.6.3
-  2.6.4
-  2.6.5
-  2.7.0-dev
-  .
-  .
-  .
+2.5.8
+2.6.6
+2.7.2
+jruby-9.2.13.0
+maglev-1.0.0
+mruby-2.1.2
+rbx-5.0
+truffleruby-20.2.0
+truffleruby+graalvm-20.2.0
+
+Only latest stable releases for each Ruby implementation are shown.
+Use 'rbenv install --list-all' to show all local versions.
 ```
 
 現在の最新のバージョンは2.6.5になるので、2.6.5のバージョンをインストールします。（2019年11月時点）


### PR DESCRIPTION
## やったこと
- `rbenv install -l`の挙動が現状の実際の実行結果と一致していなかった(現在は`--list-all`オプションをつけないと修正前と同様の出力にならない)ため、Rails6の環境構築を参考に現状のrbenvの挙動を反映しました
- 現在ruby2.6系は2.6.6が最新のため、rubyのバーションを2.6.5 => 2.6.6 に修正しました。